### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ MetaSword/
 
 ## 项目发展
 
-[![Star History Chart](https://api.star-history.com/svg?repos=soevai/MetaSword&type=Date&theme=light&DateInterval=Monthly)](https://star-history.com/#soevai/MetaSword&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=soevai/MetaSword&type=Date&theme=light&DateInterval=Monthly)](https://star-history.dera.page/#soevai/MetaSword&Date)
 
 ## 作者留言
 


### PR DESCRIPTION
The star history chart in the README was not rendering because of GitHub stargazer API restrictions. This update points the chart at a working source so it displays correctly again.